### PR TITLE
Add a feature to allow specifying a custom mono runtime library.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,8 @@ referenced_objects = []
 old_gc_unsafe = []
 
 profiler_api= []
+# Allows a different Mono dynamic library to be linked, in case the library differs (e.g. in some Unity builds)
+# As this is highly unsafe (the user needs to verify himself if the alternative library is ABI/API-compatible)
+# this feature should be used with caution. The only use case for this is for debugging other applications in my
+# knowledge.
+mono_lib_fom_env = []

--- a/build.rs
+++ b/build.rs
@@ -138,7 +138,22 @@ mod os_specific {
         Err(errors)
     }
     pub fn insert_link_args() {
+        #[cfg(feature = "mono_lib_fom_env")]{
+            /*
+            This unsafe is only semantic, but this operation can lead to highly unsafe behavior during
+            runtime due to a mismatch in the actual dll in use.
+             */
+            unsafe {
+                if let Ok(env_val) = std::env::var("MONO_LIB_NAME"){
+                    println!("cargo:rustc-link-lib={env_val}");
+                }else{
+                    panic!("The environment variable MONO_LIB_NAME must be set as you are using the feature `mono_lib_fom_env`");
+                }
+            }
+        }
+        #[cfg(not(feature = "mono_lib_fom_env"))]
         println!("cargo:rustc-link-lib=mono-2.0");
+
         println!("cargo:rustc-link-lib=stdc++");
         println!("cargo:rustc-link-lib=z");
     }


### PR DESCRIPTION
It can be specified in the env var MONO_LIB_NAME. This is mostly to allow a much easier interop in case you use this project within a custom application running inside another project. For example this should allow debuggers to use mono inside of foreign programs. 

I don't know if this is out of scope for this project, but it does not seem like too much of an addition.

If there is anything missing let me know :)

Thanks! 