### PR TITLE
Fix linking issues on windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -82,8 +82,6 @@ fn target_dir() -> String {
         .unwrap() //build
         .parent()
         .unwrap() //debug
-        .parent()
-        .unwrap() //target
         .to_str()
         .unwrap()
         .to_owned();
@@ -180,6 +178,7 @@ mod os_specific {
         println!("cargo:rustc-link-search=C:\\Program Files\\Mono\\lib");
 
         println!("cargo:rustc-link-lib=libmono-static-sgen");
+        println!("cargo:rustc-link-lib=bcrypt");
         println!("cargo:rustc-link-lib=winmm");
         println!("cargo:rustc-link-lib=ole32");
         println!("cargo:rustc-link-lib=user32");
@@ -205,12 +204,12 @@ mod os_specific {
         let trgt_dir = crate::target_dir();
         for version in versions {
             let spath_str =
-                ("C:\\Program Files\\Mono\\lib\\mono\\".to_owned() + version + "\\mscorlib.dll");
+                "C:\\Program Files\\Mono\\lib\\mono\\".to_owned() + version + "\\mscorlib.dll";
             let spath = Path::new(&spath_str);
-            let tpath_str = (&trgt_dir).to_owned() + "\\lib\\mono\\" + version + "\\mscorlib.dll";
+            let tpath_str = trgt_dir.to_owned() + "\\lib\\mono\\" + version + "\\mscorlib.dll";
             let tpath = Path::new(&tpath_str);
-            std::fs::create_dir_all(Path::new(
-                &((&trgt_dir).to_owned() + "\\lib\\mono\\" + version),
+            _ = std::fs::create_dir_all(Path::new(
+                &(trgt_dir.to_owned() + "\\lib\\mono\\" + version),
             ));
             match std::fs::copy(spath, tpath) {
                 Ok(_) => (),


### PR DESCRIPTION
I am creating a project where I embed C# in rust. Note `<target dir>` replaces the full path to the projects full path to the `target` output directory.

```
error: linking with `link.exe` failed: exit code: 1120
         ...
          libmono-static-sgen.lib(mono-rand-windows.obj) : error LNK2019: unresolved external symbol BCryptGenRandom referenced in function mono_rand_try_get_bytes
          <target dir>\debug\examples\mono.exe : fatal error LNK1120: 1 unresolved externals
```
I primarily use Windows, and when I attempting to build it failed to link because it was missing the `bcrypt.lib` link.

```
The assembly mscorlib.dll was not found or could not be loaded.
It should have been installed in the `<target dir>\debug\lib\mono\4.5\mscorlib.dll' directory.
error: process didn't exit successfully: `target\debug\examples\mono.exe` (exit code: 1)
```
Then when I built the project again it had an error because it expected the copied DLLs to be in the path `<target dir>/debug/lib/mono` instead of `<target dir>/lib/mono`. I just removed one parent call from the target dir and now they are copied to the correct location and everything builds and runs as expected.